### PR TITLE
Silence poppler warnings and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,30 @@ pip install git+https://github.com/izderadicka/pdfparser
 pip install cython
 pip install git+https://github.com/izderadicka/pdfparser
 ```
-    
+
+## Usage
+
+See `tests/dump_file.py` for available arguments and some basic example.
+```
+usage: dump_file.py [-h] [--char-details] [-f FIRST_PAGE] [-l LAST_PAGE]
+                    [--phys-layout] [--fixed-pitch FIXED_PITCH] [-q]
+                    document
+
+positional arguments:
+  document              Document file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --char-details        print character details
+  -f FIRST_PAGE, --first-page FIRST_PAGE
+                        first page
+  -l LAST_PAGE, --last-page LAST_PAGE
+                        first page
+  --phys-layout         Physical Layout - param for text analysis
+  --fixed-pitch FIXED_PITCH
+                        Fixed pitch - param for text analysis - app. max space size
+  -q, --quiet           Silence all output from poppler
+```
 
 ## Speed comparisons
 

--- a/pdfparser/poppler.pyx
+++ b/pdfparser/poppler.pyx
@@ -15,7 +15,8 @@ def poppler_version():
 cdef extern from "GlobalParams.h":
     GlobalParams *globalParams
     cdef cppclass GlobalParams:
-        pass
+        void setErrQuiet(bool)
+        bool getErrQuiet()
  # we need to init globalParams - just once during program run
 globalParams = new GlobalParams()
 
@@ -112,11 +113,14 @@ cdef class Document:
         int _pg
         PyBool phys_layout
         double fixed_pitch
-    def __cinit__(self, char *fname, PyBool phys_layout=False, double fixed_pitch=0):
+    def __cinit__(self, char *fname, PyBool phys_layout=False, double fixed_pitch=0, PyBool quiet=False):
         self._doc=PDFDocFactory().createPDFDoc(GooString(fname))
         self._pg=0
         self.phys_layout=phys_layout
         self.fixed_pitch=fixed_pitch
+
+        if quiet:
+            globalParams.setErrQuiet(True)
         
     def __dealloc__(self):
         if self._doc != NULL:

--- a/tests/dump_file.py
+++ b/tests/dump_file.py
@@ -12,8 +12,9 @@ p.add_argument('-f', '--first-page', type=int, help='first page')
 p.add_argument('-l', '--last-page', type=int, help='first page')
 p.add_argument('--phys-layout', action='store_true', help='Physical Layout - param for text analysis')
 p.add_argument('--fixed-pitch', type=float, default=0.0, help='Fixed pitch - param for text analysis - app. max space size')
+p.add_argument('-q', '--quiet', action='store_true', help='Silence all output from poppler')
 args=p.parse_args()
-d=pdf.Document(args.document, args.phys_layout, args.fixed_pitch)  # @UndefinedVariable
+d=pdf.Document(args.document, args.phys_layout, args.fixed_pitch, args.quiet)  # @UndefinedVariable
 fp=args.first_page or 1
 lp=args.last_page or d.no_of_pages
 print 'No of pages', d.no_of_pages


### PR DESCRIPTION
Uses setErrQuiet method in poppler GlobalParams.h to silence all warning and other output, fixes #15. Also added an example of usage.