### PR TITLE
Changed API to match updated poppler API, Fix #18

### DIFF
--- a/pdfparser/poppler.pyx
+++ b/pdfparser/poppler.pyx
@@ -24,7 +24,7 @@ cdef extern from "goo/GooString.h":
     cdef cppclass GooString:
         GooString(const char *sA)
         int getLength()
-        char *getCString()
+        const char *getCString()
         char getChar(int i)
 
 cdef extern from "OutputDev.h":


### PR DESCRIPTION
@izderadicka With reference to https://github.com/izderadicka/pdfparser/issues/18

Played with this for a bit, it seems like more of an API difference, and not specific build params

GooString.getCString should return a `const char *` , rather than `char *`
https://github.com/izderadicka/pdfparser/blob/master/pdfparser/poppler.pyx#L27

So changing this line to:
`        const char *getCString()`

Solved the issue for me.

It seems like this is the poppler commit (2010) that changed this API:
https://github.com/danigm/poppler/commit/a28be8e4009b86fdfd92da928def194225a736c6

Maybe Mac default c++ compiler is just more strict about this?
