### PR TITLE
Mojave build fix + use c_str (poppler 0.74.0 GooString)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,11 @@ import subprocess
 import sys
 import re
 
-from setuptools import Extension, setup
+from setuptools import setup
 
 try:
     from Cython.Build import cythonize
+    from Cython.Distutils import Extension, build_ext
 except ImportError:
     print('You need to install cython first - sudo pip install cython', file=sys.stderr)
     sys.exit(1)
@@ -62,6 +63,14 @@ def pkgconfig(*packages, **kw):
             config.setdefault(distutils_key, []).extend([i[n:] for i in items])
     return config
 
+# Poppler 0.72.0+ GooString.h uses c_str() instead of getCString()
+def use_poppler_cstring(path):
+    for el in path.split(os.path.sep)[::-1]:
+        version = el.split('.')
+        if len(version) == 3 and int(version[0]) == 0 and int(version[1]) < 72:
+            return False
+    return True
+
 # Mac OS build fix:
 mac_compile_args = ["-std=c++11", "-stdlib=libc++", "-mmacosx-version-min=10.7"]
 POPPLER_ROOT = os.environ.get('POPPLER_ROOT', None)
@@ -72,13 +81,19 @@ if POPPLER_ROOT:
                             include_dirs=[POPPLER_ROOT, os.path.join(POPPLER_ROOT, 'poppler')],
                             library_dirs=[POPPLER_ROOT, POPPLER_CPP_LIB_DIR],
                             runtime_library_dirs=['$ORIGIN'],
-                            libraries=['poppler','poppler-cpp'])
+                            libraries=['poppler','poppler-cpp'],
+                            cython_compile_time_env={'USE_CSTRING': use_poppler_cstring(POPPLER_ROOT)})
     package_data = {'pdfparser': ['*.so.*', 'pdfparser/*.so.*']}
 else:
     poppler_config = pkgconfig("poppler", "poppler-cpp")
     # Mac OS build fix:
     if sys.platform == 'darwin':
         poppler_config.setdefault('extra_compile_args', []).extend(mac_compile_args)
+        poppler_config.setdefault('extra_link_args', []).extend(mac_compile_args)
+
+    poppler_config.setdefault('cython_compile_time_env', {}).update({
+        'USE_CSTRING': use_poppler_cstring(poppler_config['include_dirs'][0])
+    })
     poppler_ext = Extension('pdfparser.poppler', ['pdfparser/poppler.pyx'], language='c++', **poppler_config)
     package_data = {}
 
@@ -86,7 +101,7 @@ else:
 pkg_file= os.path.join(os.path.split(__file__)[0], 'pdfparser', '__init__.py')
 m=re.search(r"__version__\s*=\s*'([\d.]+)'", open(pkg_file).read())
 if not m:
-    print >>sys.stderr, 'Cannot find version of package'
+    print (sys.stderr, 'Cannot find version of package')
     sys.exit(1)
 version= m.group(1)
 
@@ -117,6 +132,8 @@ setup(name='pdfparser',
       packages=['pdfparser', ],
       package_data=package_data,
       include_package_data=True,
-      ext_modules=cythonize([poppler_ext]), # a workaround since Extension is an old-style class
+      cmdclass={"build_ext": build_ext},
+      ext_modules=[poppler_ext], # a workaround since Extension is an old-style class
+                                 # removed cythonize for the list in ext_modules
       zip_safe=False
       )

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ def pkgconfig(*packages, **kw):
 def use_poppler_cstring(path):
     for el in path.split(os.path.sep)[::-1]:
         version = el.split('.')
-        if len(version) == 3 and int(version[0]) == 0 and int(version[1]) < 72:
-            return False
-    return True
+        if len(version) == 3 and (int(version[0]) > 0 or int(version[1]) >= 72):
+            return True
+    return False
 
 # Mac OS build fix:
 mac_compile_args = ["-std=c++11", "-stdlib=libc++", "-mmacosx-version-min=10.7"]


### PR DESCRIPTION
I am using macOS Mojave and was unable to build this package. This pull request fixes the two issues - `getCString` error and compiler flag issue in Mojave. 

## Reproduction
```
conda create -n myenv python=3.7 cython
conda activate myenv
pip install git+https://github.com/izderadicka/pdfparser
```

## `getCString` error (`goo/GooString`)
First error is about `getCString`, see:
```
  pdfparser/poppler.cpp:8811:41: error: no member named 'getCString' in 'GooString'
          __pyx_t_12 = __pyx_v_font_name->getCString();
                       ~~~~~~~~~~~~~~~~~  ^
  pdfparser/poppler.cpp:8910:29: error: no member named 'getCString' in 'GooString'
      __pyx_t_12 = __pyx_v_s->getCString();
                   ~~~~~~~~~  ^
```

### Solution
If I check the header file, then I see that for poppler 0.74.0 there is no `getCString`, and instead `c_str()` should be used. The proposed code changes should be backwards compatible with older Poppler versions - in the code I used conditional compilation with variable `USE_CSTRING` in Cython.

File: `/usr/local/Cellar/poppler/0.74.0/include/poppler/goo/GooString.h`

This change was in `Poppler 0.72.0`, see
https://gitlab.freedesktop.org/poppler/poppler/commit/817b0f12453985c416a0388cdd4a09697d092b7f

## macOS Mojave issue with `libc++` CFLAG
When poppler config contains only `extra_compile_args`, they don't get propagated to the `g++`:
```
poppler_config.setdefault('extra_compile_args', []).extend(mac_compile_args)
```

I get the error:
```
g++ -bundle -undefined dynamic_lookup -L/Users/myname/miniconda3/envs/myenv/lib -arch x86_64 -L/Users/myname/miniconda3/envs/myenv/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.7/pdfparser/poppler.o -L/usr/local/Cellar/poppler/0.74.0/lib -L/usr/local/Cellar/poppler/0.74.0/lib -lpoppler -lpoppler-cpp -o build/lib.macosx-10.7-x86_64-3.7/pdfparser/poppler.cpython-37m-darwin.so
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
ld: library not found for -lstdc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
error: command 'g++' failed with exit status 1
```

### Solution
Add `extra_link_args`, then `g++` command will contain `-std=c++11 -stdlib=libc++ -mmacosx-version-min=10.7` flags at the end:
```
poppler_config.setdefault('extra_compile_args', []).extend(mac_compile_args)
poppler_config.setdefault('extra_link_args', []).extend(mac_compile_args)
```

There is also a **workaround** by just specifying the compiler flag in the command line:
```
CFLAGS=-stdlib=libc++ python3 setup.py sdist bdist_wheel
```
